### PR TITLE
fix: add exotic-industries-graphics-2 to required mods list

### DIFF
--- a/info.json
+++ b/info.json
@@ -9,6 +9,7 @@
         "base >= 1.0.0",
         "exotic-industries",
         "exotic-industries-graphics",
+        "exotic-industries-graphics-2",
         "exotic-industries-loaders",
         "exotic-industries-containers",
         "exotic-industries-robots",


### PR DESCRIPTION
As mentioned in the base mod's info.json file: https://github.com/PreLeyZero/exotic-industries/blob/main/info.json#L12C10-L12C38